### PR TITLE
Trim all whitespace from station names

### DIFF
--- a/bin/scrape.js
+++ b/bin/scrape.js
@@ -100,7 +100,7 @@ ldfetch.get('https://irail.be/stations/NMBS/').then((response) => {
       }
       object.generatedAtTime = (new Date()).toISOString();
       object.properties = {
-        "@id": "http://irail.be/stations/bluebike/" + encodeURIComponent(data.name),
+        "@id": "http://irail.be/stations/bluebike/" + encodeURIComponent(data.name.replace(' ','')),
         "@type": "http://schema.org/ParkingFacility",
         "name": data.name,
         "longitude": data.lon,


### PR DESCRIPTION
`http://irail.be/stations/bluebike/Brussel%20Noord` will now become `http://irail.be/stations/bluebike/BrusselNoord`

Closes #1